### PR TITLE
your delete flow was forcing cooldown back to 30 when config was 0.

### DIFF
--- a/controllers/user_controller.py
+++ b/controllers/user_controller.py
@@ -688,7 +688,8 @@ def register_fcm_token():
 def delete_user_id():
     user_id = g.auth_user_id
     try:
-        cooldown_days = max(0, int(current_app.config.get("USER_DELETION_COOLDOWN_DAYS", 30) or 30))
+        cooldown_days_cfg = current_app.config.get("USER_DELETION_COOLDOWN_DAYS", 30)
+        cooldown_days = max(0, int(30 if cooldown_days_cfg is None else cooldown_days_cfg))
         cooldown_expires_at = datetime.utcnow() + timedelta(days=cooldown_days)
         user_row = db.session.execute(text("""
             SELECT u.id, u.referred_by, c.email, c.phone
@@ -701,21 +702,22 @@ def delete_user_id():
         if not user_row:
             return jsonify({"message": "User not found"}), 404
 
-        db.session.execute(text("""
-            INSERT INTO deleted_user_cooldown (email, phone, referred_by, created_at, expires_at)
-            VALUES (
-                COALESCE(:email, ''),
-                COALESCE(:phone, ''),
-                :referred_by,
-                NOW(),
-                :expires_at
-            )
-        """), {
-            "email": user_row.get("email"),
-            "phone": user_row.get("phone"),
-            "referred_by": user_row.get("referred_by"),
-            "expires_at": cooldown_expires_at,
-        })
+        if cooldown_days > 0:
+            db.session.execute(text("""
+                INSERT INTO deleted_user_cooldown (email, phone, referred_by, created_at, expires_at)
+                VALUES (
+                    COALESCE(:email, ''),
+                    COALESCE(:phone, ''),
+                    :referred_by,
+                    NOW(),
+                    :expires_at
+                )
+            """), {
+                "email": user_row.get("email"),
+                "phone": user_row.get("phone"),
+                "referred_by": user_row.get("referred_by"),
+                "expires_at": cooldown_expires_at,
+            })
 
         db.session.execute(text("""
             DELETE FROM monthly_credit_ledgers

--- a/services/user_service.py
+++ b/services/user_service.py
@@ -529,6 +529,10 @@ class UserService:
         """Check if email or phone is in cooldown period"""
         if not email and not phone:
             return False
+        cooldown_days_cfg = current_app.config.get("USER_DELETION_COOLDOWN_DAYS", 30)
+        cooldown_days = max(0, int(30 if cooldown_days_cfg is None else cooldown_days_cfg))
+        if cooldown_days <= 0:
+            return False
         now = datetime.utcnow()
         predicates = []
         if email:


### PR DESCRIPTION
The bug was this pattern:

int(config_value or 30)
When config_value = 0, Python treats it as falsy, so it became 30. I fixed it end-to-end in hfg-user-onboard:

DELETE /api/users now preserves 0 correctly and does not create cooldown rows when cooldown is disabled. user_controller
PY
Signup cooldown check now short-circuits when USER_DELETION_COOLDOWN_DAYS <= 0, so even old cooldown rows won’t block recreate flow when cooldown is disabled. user_service
PY