### PR TITLE
Added migration for game-to-console mapping and analytics in 20260604…

### DIFF
--- a/controllers/event_participation_controller.py
+++ b/controllers/event_participation_controller.py
@@ -15,7 +15,7 @@ from models.registration import Registration
 from models.notification import Notification
 from models.fcmToken import FCMToken
 from models.user import User
-from services.payment_service import create_payment_intent, verify_webhook
+from services.payment_service import create_payment_intent, verify_payment_success, verify_webhook
 from services.firebase_service import send_notification
 
 
@@ -24,6 +24,13 @@ IST = ZoneInfo("Asia/Kolkata")
 _PUSH_EXECUTOR = ThreadPoolExecutor(max_workers=int(os.getenv("FCM_PUSH_WORKERS", "16")))
 _EVENT_PARTICIPATION_CACHE = {}
 _EVENT_PARTICIPATION_CACHE_MAX_SIZE = 5000
+
+
+def _mark_registration_payment(reg, status):
+    reg.payment_status = "paid" if status == "succeeded" else "failed"
+    reg.status = "confirmed" if status == "succeeded" else "pending"
+    _invalidate_participation_cache(event_id=reg.event_id, team_id=reg.team_id)
+    db.session.commit()
 
 
 def _event_flag(start_at, end_at):
@@ -559,7 +566,7 @@ def make_payment_intent():
 @event_participation_bp.post("/payments/webhook")
 def payment_webhook():
     payload = request.get_data()
-    sig = request.headers.get("X-Signature", "")
+    sig = request.headers.get("X-Razorpay-Signature") or request.headers.get("X-Signature", "")
     ok, reg_id, status = verify_webhook(payload, sig)
 
     if not ok:
@@ -569,12 +576,28 @@ def payment_webhook():
     if not reg:
         return jsonify({"error": "registration not found"}), 404
 
-    reg.payment_status = "paid" if status == "succeeded" else "failed"
-    reg.status = "confirmed" if status == "succeeded" else "pending"
+    _mark_registration_payment(reg, status)
 
-    db.session.commit()
+    return jsonify({"ok": True, "registration_id": str(reg.id), "payment_status": reg.payment_status, "status": reg.status}), 200
 
-    return jsonify({"ok": True}), 200
+@event_participation_bp.post("/payments/verify")
+def verify_payment():
+    body = _body()
+    ok, reg_id, status = verify_payment_success(body)
+    if not ok:
+        return jsonify({"error": "payment verification failed"}), 400
+
+    reg = Registration.query.filter_by(id=reg_id).first()
+    if not reg:
+        return jsonify({"error": "registration not found"}), 404
+
+    _mark_registration_payment(reg, status)
+    return jsonify({
+        "ok": True,
+        "registration_id": str(reg.id),
+        "payment_status": reg.payment_status,
+        "status": reg.status,
+    }), 200
 
 @event_participation_bp.get("/events/<uuid:event_id>/teams/<uuid:team_id>/members")
 def get_team_members(event_id, team_id):

--- a/services/payment_service.py
+++ b/services/payment_service.py
@@ -38,6 +38,20 @@ def verify_webhook(payload: bytes, signature: str) -> Tuple[bool, str, str]:
     else:
         return _mock_verify_webhook(payload, signature)
 
+
+def verify_payment_success(data: Dict[str, Any]) -> Tuple[bool, str, str]:
+    """
+    Verifies a client-side payment success callback.
+    Returns (ok, registration_id, status), where status is "succeeded" | "failed".
+    """
+    if PROVIDER == "razorpay":
+        return _rzp_verify_payment_success(data)
+    elif PROVIDER == "stripe":
+        return False, None, "failed"
+    else:
+        reg_id = str(data.get("registration_id") or "")
+        return bool(reg_id), reg_id, "succeeded" if reg_id else "failed"
+
 # ---------------------------
 # Mock provider (for dev/test)
 # ---------------------------
@@ -122,9 +136,17 @@ def _rzp_verify_webhook(payload: bytes, signature: str) -> Tuple[bool, str, str]
 
     # Map event types -> registration_id, status
     # Expect registration_id in notes/metadata
-    entity = event.get("payload", {}).get("payment", {}).get("entity", {}) or event.get("payload", {}).get("order", {}).get("entity", {})
+    payload_data = event.get("payload", {})
+    payment_entity = payload_data.get("payment", {}).get("entity", {}) or {}
+    order_entity = payload_data.get("order", {}).get("entity", {}) or {}
+    entity = payment_entity or order_entity
     notes = entity.get("notes", {}) if isinstance(entity, dict) else {}
-    reg_id = notes.get("registration_id")
+    reg_id = (
+        notes.get("registration_id")
+        or order_entity.get("notes", {}).get("registration_id")
+        or order_entity.get("receipt")
+        or entity.get("receipt")
+    )
 
     # Infer status
     event_type = event.get("event")
@@ -136,6 +158,47 @@ def _rzp_verify_webhook(payload: bytes, signature: str) -> Tuple[bool, str, str]
         status = "failed"
 
     return True, reg_id, status
+
+
+def _rzp_verify_payment_success(data: Dict[str, Any]) -> Tuple[bool, str, str]:
+    key_secret = os.getenv("RAZORPAY_KEY_SECRET")
+    if not key_secret:
+        return False, None, "failed"
+
+    order_id = data.get("razorpay_order_id") or data.get("order_id")
+    payment_id = data.get("razorpay_payment_id") or data.get("payment_id")
+    signature = data.get("razorpay_signature") or data.get("signature")
+    registration_id = str(data.get("registration_id") or "")
+    if not order_id or not payment_id or not signature or not registration_id:
+        return False, None, "failed"
+
+    message = f"{order_id}|{payment_id}".encode("utf-8")
+    expected = hmac.new(
+        key=key_secret.encode("utf-8"),
+        msg=message,
+        digestmod=hashlib.sha256
+    ).hexdigest()
+    if not hmac.compare_digest(expected, signature):
+        return False, None, "failed"
+
+    try:
+        import requests
+        key_id = os.getenv("RAZORPAY_KEY_ID")
+        if key_id:
+            resp = requests.get(
+                f"https://api.razorpay.com/v1/orders/{order_id}",
+                auth=(key_id, key_secret),
+                timeout=10,
+            )
+            resp.raise_for_status()
+            order = resp.json()
+            notes = order.get("notes") or {}
+            if str(order.get("receipt") or notes.get("registration_id") or "") != registration_id:
+                return False, None, "failed"
+    except Exception:
+        return False, None, "failed"
+
+    return True, registration_id, "succeeded"
 
 # ---------------------------
 # Stripe (outline)


### PR DESCRIPTION
…_game_discovery_catalog.sql (line 1).

Added app game APIs in vendor_games.py (line 24):GET /api/games/platforms GET /api/games/popular?console_slug=pc&city=Hyderabad GET /api/games/search?console_slug=pc&q=valorant
POST /api/games/discovery-events

Added cached discovery/query logic in game_service.py (line 10). Kept existing /api/games untouched for legacy/admin use. Documented the app flow in frontend-api.md (line 138). Migration Notes
Maps PC/Linux/macOS/Web/Classic Macintosh -> pc
Maps PlayStation 2/3/4/5/PS Vita -> playstation
Maps Xbox/Xbox One/Xbox 360/Xbox Series S/X -> xbox Maps Nintendo Switch -> nintendo_switch
Leaves Android/iOS/Dreamcast/SEGA/GameCube/Wii U/Nintendo DS unmapped for now because your console_catalog has no matching active category.